### PR TITLE
feat: add GitHub Actions CI, Linux build support, and headless CLI renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build & Test / ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-22.04
+            qt-arch: ""
+          - name: Windows
+            os: windows-latest
+            qt-arch: win64_msvc2019_64
+          - name: macOS
+            os: macos-latest
+            qt-arch: clang_64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: "6.7.3"
+          arch: ${{ matrix.qt-arch }}
+          modules: "qtmultimedia"
+          cache: true
+
+      - name: Platform dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y ninja-build libeigen3-dev libgl1-mesa-dev libglu1-mesa-dev
+
+      - name: Platform dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ninja eigen
+
+      - name: Platform dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ninja --no-progress
+
+      - name: Set up MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Configure
+        run: cmake --preset test
+
+      - name: Build
+        run: cmake --build --preset test
+
+      - name: Test
+        run: ctest --preset test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,20 @@ if(NOT Eigen3_FOUND)
         GIT_TAG        3.4.0
         GIT_SHALLOW    TRUE
     )
-    set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
-    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
-    set(EIGEN_BUILD_PKGCONFIG OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(eigen)
+    # Use Populate (not MakeAvailable) to skip Eigen's CMakeLists.txt entirely.
+    # MakeAvailable triggers BLAS detection which calls enable_language(Fortran)
+    # and fails on CI runners that have a broken gfortran in PATH.
+    # Eigen is header-only for our use; no Fortran is needed.
+    FetchContent_GetProperties(eigen)
+    if(NOT eigen_POPULATED)
+        if(POLICY CMP0168)
+            cmake_policy(SET CMP0168 OLD) # suppress FetchContent_Populate deprecation (CMake 3.30+)
+        endif()
+        FetchContent_Populate(eigen)
+    endif()
+    add_library(Eigen3::Eigen INTERFACE IMPORTED GLOBAL)
+    target_include_directories(Eigen3::Eigen INTERFACE "${eigen_SOURCE_DIR}")
+    set(EIGEN3_INCLUDE_DIR "${eigen_SOURCE_DIR}")
 endif()
 
 find_package(OpenMP)
@@ -67,6 +77,7 @@ set(SOURCES
     src/acoustics/RoomImpulseResponse.cpp
     src/acoustics/Wall.cpp
     src/acoustics/SimulationWorker.cpp
+    src/acoustics/RenderExports.cpp
     src/acoustics/SimulationQueue.cpp
     src/acoustics/AcousticMetrics.cpp
     src/acoustics/dg/DGBasis2D.cpp
@@ -121,6 +132,9 @@ set(HEADERS
     src/acoustics/RoomImpulseResponse.h
     src/acoustics/Wall.h
     src/acoustics/SimulationWorker.h
+    src/acoustics/RenderOptions.h
+    src/acoustics/RenderExports.h
+    src/acoustics/RenderPipeline.h
     src/acoustics/SimulationQueue.h
     src/acoustics/AcousticMetrics.h
     src/acoustics/dg/DGTypes.h
@@ -216,6 +230,95 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 )
 
 install(TARGETS ${PROJECT_NAME}
+    BUNDLE DESTINATION .
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# ── Headless CLI render tool ─────────────────────────────────────────────────
+set(CLI_SOURCES
+    src/cli/main.cpp
+    src/core/Material.cpp
+    src/core/MaterialLoader.cpp
+    src/core/SoundSource.cpp
+    src/core/Listener.cpp
+    src/core/PlacedPoint.cpp
+    src/core/ProjectFile.cpp
+    src/scene/SceneManager.cpp
+    src/rendering/Camera.cpp
+    src/rendering/MeshData.cpp
+    src/rendering/SurfaceGrouper.cpp
+    src/rendering/RayPicking.cpp
+    src/rendering/MeshSimplifier.cpp
+    src/rendering/TextureManager.cpp
+    src/acoustics/AcousticSimulator.cpp
+    src/acoustics/Bvh.cpp
+    src/acoustics/ImageSourceMethod.cpp
+    src/acoustics/RayTracer.cpp
+    src/acoustics/RoomImpulseResponse.cpp
+    src/acoustics/Wall.cpp
+    src/acoustics/SimulationWorker.cpp
+    src/acoustics/RenderExports.cpp
+    src/acoustics/RenderPipeline.cpp
+    src/acoustics/AcousticMetrics.cpp
+    src/acoustics/dg/DGBasis2D.cpp
+    src/acoustics/dg/DGBasis3D.cpp
+    src/acoustics/dg/DGMesh2D.cpp
+    src/acoustics/dg/DGMesh3D.cpp
+    src/acoustics/dg/DGAcoustics2D.cpp
+    src/acoustics/dg/DGAcoustics3D.cpp
+    src/acoustics/dg/DGSolver.cpp
+    src/acoustics/dg/DGGpuCompute.cpp
+    src/audio/AudioFile.cpp
+    src/audio/SignalProcessing.cpp
+    src/utils/ResourcePath.cpp
+)
+
+add_executable(SeicheRender ${CLI_SOURCES})
+
+target_include_directories(SeicheRender PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${EIGEN3_INCLUDE_DIR}
+)
+
+target_link_libraries(SeicheRender PRIVATE
+    Qt6::Widgets
+    Qt6::OpenGL
+    Qt6::OpenGLWidgets
+    Qt6::Multimedia
+    Qt6::Svg
+    Eigen3::Eigen
+)
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(SeicheRender PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+if(SNDFILE_LIBRARIES)
+    target_include_directories(SeicheRender PRIVATE ${SNDFILE_INCLUDE_DIRS})
+    target_link_libraries(SeicheRender PRIVATE ${SNDFILE_LIBRARIES})
+    target_compile_definitions(SeicheRender PRIVATE HAS_SNDFILE)
+endif()
+
+if(FFTW3_LIBRARIES)
+    target_include_directories(SeicheRender PRIVATE ${FFTW3_INCLUDE_DIRS})
+    target_link_libraries(SeicheRender PRIVATE ${FFTW3_LIBRARIES})
+    target_compile_definitions(SeicheRender PRIVATE HAS_FFTW3)
+endif()
+
+if(WIN32)
+    target_link_libraries(SeicheRender PRIVATE opengl32 glu32)
+elseif(APPLE)
+    find_package(OpenGL REQUIRED)
+    target_link_libraries(SeicheRender PRIVATE OpenGL::GL OpenGL::GLU)
+else()
+    find_package(OpenGL REQUIRED)
+    target_link_libraries(SeicheRender PRIVATE OpenGL::GL OpenGL::GLU)
+endif()
+
+target_compile_definitions(SeicheRender PRIVATE _USE_MATH_DEFINES)
+
+install(TARGETS SeicheRender
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,62 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": { "major": 3, "minor": 21, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}"
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "displayName": "Debug",
+      "description": "Debug build with symbols and assertions",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "displayName": "Release",
+      "description": "Optimised release build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "test",
+      "inherits": "debug",
+      "displayName": "Test",
+      "description": "Debug build used for running the Qt test suite"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "test",
+      "configurePreset": "test"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test",
+      "configurePreset": "test",
+      "output": {
+        "outputOnFailure": true
+      },
+      "environment": {
+        "QT_QPA_PLATFORM": "offscreen"
+      }
+    }
+  ]
+}

--- a/src/acoustics/RenderExports.cpp
+++ b/src/acoustics/RenderExports.cpp
@@ -1,0 +1,99 @@
+#include "RenderExports.h"
+
+#include "audio/AudioFile.h"
+
+#include <QFile>
+#include <QJsonDocument>
+
+namespace prs::RenderExports {
+
+namespace {
+
+QString csvEscape(const QString& value) {
+    QString out = value;
+    out.replace('"', "\"\"");
+    if (out.contains(',') || out.contains('"') || out.contains('\n'))
+        return '"' + out + '"';
+    return out;
+}
+
+QString metricString(const QJsonObject& pair, const char* section, const char* key) {
+    if (!pair.contains(section) || !pair.value(section).isObject())
+        return {};
+    const QJsonObject obj = pair.value(section).toObject();
+    if (!obj.contains(key))
+        return {};
+    return QString::number(obj.value(key).toDouble(), 'f', 6);
+}
+
+} // namespace
+
+bool saveMonoWav(const QString& path, int sampleRate, const std::vector<float>& samples) {
+    AudioFile file;
+    file.samples() = samples;
+    return file.save(path, sampleRate);
+}
+
+bool saveStereoWav(const QString& path, int sampleRate, const std::vector<float>& left,
+                   const std::vector<float>& right) {
+    return AudioFile::saveStereo(path, sampleRate, left, right);
+}
+
+QJsonObject buildMetricsSummary(const QJsonArray& pairs, int sampleRate) {
+    QJsonObject summary;
+    summary["version"] = "1.0";
+    summary["sample_rate"] = sampleRate;
+    summary["pair_count"] = pairs.size();
+    return summary;
+}
+
+bool saveJsonObject(const QString& path, const QJsonObject& obj) {
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    file.write(QJsonDocument(obj).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+bool saveMetricsCsv(const QString& path, const QJsonArray& pairs) {
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
+        return false;
+
+    QByteArray contents;
+    contents += "source,listener,t20,t30,edt,direct_dB,reflected_dB,total_dB\n";
+    for (const auto& pairVal : pairs) {
+        if (!pairVal.isObject())
+            continue;
+        const QJsonObject pair = pairVal.toObject();
+        const QString source = csvEscape(pair.value("source").toString());
+        const QString listener = csvEscape(pair.value("listener").toString());
+        const QString t20 = metricString(pair, "reverberation_time", "T20");
+        const QString t30 = metricString(pair, "reverberation_time", "T30");
+        const QString edt = metricString(pair, "reverberation_time", "EDT");
+        const QString direct = metricString(pair, "sound_pressure_level", "direct_dB");
+        const QString reflected = metricString(pair, "sound_pressure_level", "reflected_dB");
+        const QString total = metricString(pair, "sound_pressure_level", "total_dB");
+
+        contents += source.toUtf8();
+        contents += ',';
+        contents += listener.toUtf8();
+        contents += ',';
+        contents += t20.toUtf8();
+        contents += ',';
+        contents += t30.toUtf8();
+        contents += ',';
+        contents += edt.toUtf8();
+        contents += ',';
+        contents += direct.toUtf8();
+        contents += ',';
+        contents += reflected.toUtf8();
+        contents += ',';
+        contents += total.toUtf8();
+        contents += '\n';
+    }
+
+    return file.write(contents) == contents.size();
+}
+
+} // namespace prs::RenderExports

--- a/src/acoustics/RenderExports.h
+++ b/src/acoustics/RenderExports.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QString>
+
+#include <vector>
+
+namespace prs::RenderExports {
+
+bool saveMonoWav(const QString& path, int sampleRate, const std::vector<float>& samples);
+bool saveStereoWav(const QString& path, int sampleRate, const std::vector<float>& left,
+                   const std::vector<float>& right);
+
+QJsonObject buildMetricsSummary(const QJsonArray& pairs, int sampleRate);
+bool saveJsonObject(const QString& path, const QJsonObject& obj);
+bool saveMetricsCsv(const QString& path, const QJsonArray& pairs);
+
+} // namespace prs::RenderExports

--- a/src/acoustics/RenderOptions.h
+++ b/src/acoustics/RenderOptions.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "core/Types.h"
+
+namespace prs {
+
+enum class RenderMethod {
+    RayTracing,
+    DG_2D,
+    DG_3D,
+};
+
+struct RenderOptions {
+    RenderMethod method = RenderMethod::RayTracing;
+    int maxOrder = DEFAULT_MAX_ORDER;
+    int nRays = DEFAULT_N_RAYS;
+    float scattering = DEFAULT_SCATTERING;
+    bool airAbsorption = true;
+    int sampleRate = DEFAULT_SAMPLE_RATE;
+    int dgPolyOrder = 3;
+    float dgMaxFrequency = 1000.0f;
+};
+
+} // namespace prs

--- a/src/acoustics/RenderPipeline.cpp
+++ b/src/acoustics/RenderPipeline.cpp
@@ -1,0 +1,119 @@
+#include "RenderPipeline.h"
+
+#include "rendering/MeshData.h"
+#include "rendering/SurfaceGrouper.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+namespace prs::RenderPipeline {
+
+namespace {
+
+QString resolveRelativePath(const QString& basePath, const QString& candidate) {
+    if (candidate.isEmpty())
+        return {};
+    QFileInfo info(candidate);
+    if (info.isAbsolute())
+        return info.filePath();
+    return QFileInfo(basePath).dir().filePath(candidate);
+}
+
+SimMethod toSimMethod(RenderMethod method) {
+    switch (method) {
+        case RenderMethod::DG_2D:
+            return SimMethod::DG_2D;
+        case RenderMethod::DG_3D:
+            return SimMethod::DG_3D;
+        case RenderMethod::RayTracing:
+        default:
+            return SimMethod::RayTracing;
+    }
+}
+
+std::vector<Viewport3D::WallInfo> buildWalls(const MeshData& mesh, const ProjectData& project) {
+    auto featureEdges = SurfaceGrouper::computeFeatureEdges(mesh, 10.0f);
+    auto surfaces = SurfaceGrouper::groupTrianglesIntoSurfaces(mesh, featureEdges);
+    std::vector<Viewport3D::WallInfo> walls;
+    walls.reserve(surfaces.size());
+
+    for (int si = 0; si < static_cast<int>(surfaces.size()); ++si) {
+        Viewport3D::WallInfo wi;
+        wi.triangleIndices.assign(surfaces[si].begin(), surfaces[si].end());
+        if (si < static_cast<int>(project.surfaceMaterials.size()) && project.surfaceMaterials[si].has_value()) {
+            wi.absorption = project.surfaceMaterials[si]->absorption;
+            wi.scattering = project.surfaceMaterials[si]->scattering;
+        }
+        walls.push_back(std::move(wi));
+    }
+
+    return walls;
+}
+
+SceneManager buildScene(const ProjectData& project, const QString& projectPath, const QString& defaultAudioFile) {
+    SceneManager scene;
+    const float scale = project.scaleFactor;
+    const QString fallbackAudio = resolveRelativePath(projectPath, defaultAudioFile);
+
+    int sourceIndex = 0;
+    int listenerIndex = 0;
+    for (const auto& pt : project.placedPoints) {
+        const Vec3f pos = pt.getPosition() * scale;
+        if (pt.pointType == POINT_TYPE_SOURCE) {
+            const QString audio = resolveRelativePath(projectPath, QString::fromStdString(pt.audioFile));
+            const std::string file = audio.isEmpty() ? fallbackAudio.toStdString() : audio.toStdString();
+            const std::string name = pt.name.empty() ? "Source " + std::to_string(++sourceIndex) : pt.name;
+            scene.addSoundSource(pos, file, pt.volume, name);
+        } else if (pt.pointType == POINT_TYPE_LISTENER) {
+            const std::string name = pt.name.empty() ? "Listener " + std::to_string(++listenerIndex) : pt.name;
+            scene.addListener(pos, name, pt.getForwardDirection());
+        }
+    }
+
+    return scene;
+}
+
+} // namespace
+
+bool buildSimulationParams(const QString& projectPath, const ProjectData& project, const RenderOptions& options,
+                           const std::vector<int>& selectedListenerIndices, const QString& outputDir,
+                           SimulationWorker::Params* params, QString* error) {
+    if (!params) {
+        if (error)
+            *error = "internal error: params output is null";
+        return false;
+    }
+
+    const QString meshPath = resolveRelativePath(projectPath, project.stlFilePath);
+    if (meshPath.isEmpty()) {
+        if (error)
+            *error = "project does not specify a room mesh";
+        return false;
+    }
+
+    MeshData mesh;
+    if (!mesh.load(meshPath)) {
+        if (error)
+            *error = QString("failed to load room mesh: %1").arg(meshPath);
+        return false;
+    }
+
+    params->scene = buildScene(project, projectPath, project.soundSourceFile);
+    params->walls = buildWalls(mesh, project);
+    params->roomCenter = mesh.center() * project.scaleFactor;
+    params->modelVertices = mesh.scaledFlatVertices(project.scaleFactor);
+    params->sampleRate = options.sampleRate;
+    params->maxOrder = options.maxOrder;
+    params->nRays = options.nRays;
+    params->scattering = options.scattering;
+    params->airAbsorption = options.airAbsorption;
+    params->selectedListenerIndices = selectedListenerIndices;
+    params->method = toSimMethod(options.method);
+    params->dgPolyOrder = options.dgPolyOrder;
+    params->dgMaxFrequency = options.dgMaxFrequency;
+    params->outputDir = outputDir;
+
+    return true;
+}
+
+} // namespace prs::RenderPipeline

--- a/src/acoustics/RenderPipeline.h
+++ b/src/acoustics/RenderPipeline.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "acoustics/SimulationWorker.h"
+#include "core/ProjectFile.h"
+#include "RenderOptions.h"
+
+#include <QString>
+
+#include <vector>
+
+namespace prs::RenderPipeline {
+
+bool buildSimulationParams(const QString& projectPath, const ProjectData& project, const RenderOptions& options,
+                           const std::vector<int>& selectedListenerIndices, const QString& outputDir,
+                           SimulationWorker::Params* params, QString* error);
+
+} // namespace prs::RenderPipeline

--- a/src/acoustics/SimulationWorker.cpp
+++ b/src/acoustics/SimulationWorker.cpp
@@ -4,6 +4,7 @@
 #include "ImageSourceMethod.h"
 #include "RayTracer.h"
 #include "RoomImpulseResponse.h"
+#include "RenderExports.h"
 #include "AcousticMetrics.h"
 #include "dg/DGSolver.h"
 #include "rendering/RayPicking.h"
@@ -185,8 +186,11 @@ void SimulationWorker::process() {
 
     if (isCancelled()) { emit error("Cancelled"); return; }
 
-    QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd_HH-mm-ss");
-    QString outputDir = QDir("sounds/simulations").filePath("simulation_" + timestamp);
+    QString outputDir = params_.outputDir;
+    if (outputDir.isEmpty()) {
+        QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd_HH-mm-ss");
+        outputDir = QDir("sounds/simulations").filePath("simulation_" + timestamp);
+    }
     QDir().mkpath(outputDir);
     scene.saveToFile(QDir(outputDir).filePath("scene.json"));
 
@@ -263,9 +267,7 @@ void SimulationWorker::process() {
                 QString listenerName = QString::fromStdString(listener->name).replace(' ', '_');
                 QString sourceName = QString::fromStdString(source->name).replace(' ', '_');
                 QString filename = QString("%1_from_%2.wav").arg(listenerName, sourceName);
-                AudioFile outFile;
-                outFile.samples() = std::move(outMono);
-                if (!outFile.save(QDir(outputDir).filePath(filename), fs))
+                if (!RenderExports::saveMonoWav(QDir(outputDir).filePath(filename), fs, outMono))
                     qWarning() << "Failed to write" << filename;
 
                 ++pairsDoneDG;
@@ -402,7 +404,7 @@ void SimulationWorker::process() {
             QString listenerName = QString::fromStdString(listener->name).replace(' ', '_');
             QString sourceName = QString::fromStdString(source->name).replace(' ', '_');
             QString filename = QString("%1_from_%2.wav").arg(listenerName, sourceName);
-            if (!AudioFile::saveStereo(QDir(outputDir).filePath(filename), fs, outLeft, outRight))
+            if (!RenderExports::saveStereoWav(QDir(outputDir).filePath(filename), fs, outLeft, outRight))
                 qWarning() << "Failed to write" << filename;
 
             MixedStereo& mix = mixedPerListener[li];
@@ -430,7 +432,7 @@ void SimulationWorker::process() {
                 for (float& s : m.right) s /= maxVal;
             }
             QString listenerName = QString::fromStdString(listener->name).replace(' ', '_');
-            AudioFile::saveStereo(QDir(outputDir).filePath(listenerName + "_mixed.wav"), mixedFs, m.left, m.right);
+            RenderExports::saveStereoWav(QDir(outputDir).filePath(listenerName + "_mixed.wav"), mixedFs, m.left, m.right);
         }
     }
 
@@ -442,11 +444,11 @@ void SimulationWorker::process() {
         metricsRoot["sample_rate"] = params_.sampleRate;
         metricsRoot["pairs"] = metricsArray;
 
-        QFile metricsFile(QDir(outputDir).filePath("metrics.json"));
-        if (metricsFile.open(QIODevice::WriteOnly)) {
-            metricsFile.write(QJsonDocument(metricsRoot).toJson(QJsonDocument::Indented));
+        if (RenderExports::saveJsonObject(QDir(outputDir).filePath("metrics.json"), metricsRoot))
             qInfo() << "Saved metrics for" << metricsArray.size() << "source-listener pairs";
-        }
+        RenderExports::saveJsonObject(QDir(outputDir).filePath("summary.json"),
+                                      RenderExports::buildMetricsSummary(metricsArray, params_.sampleRate));
+        RenderExports::saveMetricsCsv(QDir(outputDir).filePath("metrics.csv"), metricsArray);
     }
 
     qInfo() << "=== SIMULATION COMPLETE in" << totalTimer.elapsed() << "ms ===";

--- a/src/acoustics/SimulationWorker.h
+++ b/src/acoustics/SimulationWorker.h
@@ -28,6 +28,7 @@ public:
         float scattering = DEFAULT_SCATTERING;
         bool airAbsorption = true;
         std::vector<int> selectedListenerIndices;
+        QString outputDir; // if empty, a timestamped subdirectory is created automatically
 
         SimMethod method = SimMethod::RayTracing;
         int dgPolyOrder = 3;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,0 +1,143 @@
+#include "acoustics/RenderOptions.h"
+#include "acoustics/RenderPipeline.h"
+#include "acoustics/SimulationWorker.h"
+#include "core/ProjectFile.h"
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QFileInfo>
+#include <QTextStream>
+
+#include <vector>
+
+namespace {
+
+bool parseOnOff(const QString& value, bool* out) {
+    const QString normalized = value.trimmed().toLower();
+    if (normalized == "on" || normalized == "true" || normalized == "1") {
+        *out = true;
+        return true;
+    }
+    if (normalized == "off" || normalized == "false" || normalized == "0") {
+        *out = false;
+        return true;
+    }
+    return false;
+}
+
+bool parseMethod(const QString& value, prs::RenderMethod* out) {
+    const QString normalized = value.trimmed().toLower();
+    if (normalized == "ray") {
+        *out = prs::RenderMethod::RayTracing;
+        return true;
+    }
+    if (normalized == "dg2d") {
+        *out = prs::RenderMethod::DG_2D;
+        return true;
+    }
+    if (normalized == "dg3d") {
+        *out = prs::RenderMethod::DG_3D;
+        return true;
+    }
+    return false;
+}
+
+void printError(const QString& message) {
+    QTextStream err(stderr);
+    err << message << '\n';
+    err.flush();
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setApplicationName("SeicheRender");
+    QCoreApplication::setApplicationVersion("1.0.0");
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Headless render entry point for Seiche");
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    QCommandLineOption projectOpt(QStringList() << "p" << "project", "Project file to render.", "file");
+    QCommandLineOption outputOpt(QStringList() << "o" << "output", "Output directory.", "dir");
+    QCommandLineOption methodOpt("method", "Render method: ray, dg2d, or dg3d.", "method");
+    QCommandLineOption maxOrderOpt("max-order", "Maximum ray tracing order.", "order");
+    QCommandLineOption nRaysOpt("n-rays", "Number of rays.", "count");
+    QCommandLineOption scatteringOpt("scattering", "Scattering coefficient.", "value");
+    QCommandLineOption airAbsorptionOpt("air-absorption", "Air absorption on or off.", "state");
+    QCommandLineOption dgPolyOpt("dg-poly-order", "DG polynomial order.", "order");
+    QCommandLineOption dgFreqOpt("dg-max-frequency", "DG maximum frequency.", "hz");
+    QCommandLineOption sampleRateOpt("sample-rate", "Override sample rate.", "hz");
+
+    parser.addOption(projectOpt);
+    parser.addOption(outputOpt);
+    parser.addOption(methodOpt);
+    parser.addOption(maxOrderOpt);
+    parser.addOption(nRaysOpt);
+    parser.addOption(scatteringOpt);
+    parser.addOption(airAbsorptionOpt);
+    parser.addOption(dgPolyOpt);
+    parser.addOption(dgFreqOpt);
+    parser.addOption(sampleRateOpt);
+
+    parser.process(app);
+
+    if (!parser.isSet(projectOpt)) {
+        printError("Missing required --project <file.room> argument.");
+        return 1;
+    }
+
+    const QString projectPath = QFileInfo(parser.value(projectOpt)).absoluteFilePath();
+    auto project = prs::ProjectFile::load(projectPath);
+    if (!project) {
+        printError(QString("Failed to load project: %1").arg(projectPath));
+        return 1;
+    }
+
+    prs::RenderOptions options;
+    if (parser.isSet(methodOpt) && !parseMethod(parser.value(methodOpt), &options.method)) {
+        printError("Invalid --method value. Use ray, dg2d, or dg3d.");
+        return 1;
+    }
+    if (parser.isSet(maxOrderOpt))
+        options.maxOrder = parser.value(maxOrderOpt).toInt();
+    if (parser.isSet(nRaysOpt))
+        options.nRays = parser.value(nRaysOpt).toInt();
+    if (parser.isSet(scatteringOpt))
+        options.scattering = parser.value(scatteringOpt).toFloat();
+    if (parser.isSet(airAbsorptionOpt) && !parseOnOff(parser.value(airAbsorptionOpt), &options.airAbsorption)) {
+        printError("Invalid --air-absorption value. Use on or off.");
+        return 1;
+    }
+    if (parser.isSet(dgPolyOpt))
+        options.dgPolyOrder = parser.value(dgPolyOpt).toInt();
+    if (parser.isSet(dgFreqOpt))
+        options.dgMaxFrequency = parser.value(dgFreqOpt).toFloat();
+    if (parser.isSet(sampleRateOpt))
+        options.sampleRate = parser.value(sampleRateOpt).toInt();
+
+    const QString outputDir =
+        parser.isSet(outputOpt) ? QFileInfo(parser.value(outputOpt)).absoluteFilePath() : QString();
+
+    prs::SimulationWorker::Params params;
+    QString error;
+    if (!prs::RenderPipeline::buildSimulationParams(projectPath, *project, options, {}, outputDir, &params, &error)) {
+        printError(error.isEmpty() ? QString("Failed to prepare render parameters for %1").arg(projectPath) : error);
+        return 1;
+    }
+
+    prs::SimulationWorker worker(params);
+    QString workerError;
+    QObject::connect(&worker, &prs::SimulationWorker::error, [&](const QString& message) { workerError = message; });
+    worker.process();
+
+    if (!workerError.isEmpty()) {
+        printError(workerError);
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/core/ProjectFile.cpp
+++ b/src/core/ProjectFile.cpp
@@ -39,6 +39,7 @@ bool ProjectFile::save(const QString& filepath, const ProjectData& data) {
     root["version"] = 1;
     root["stlFilePath"] = data.stlFilePath;
     root["scaleFactor"] = static_cast<double>(data.scaleFactor);
+    root["sampleRate"] = data.sampleRate;
     root["soundSourceFile"] = data.soundSourceFile;
 
     QJsonArray colorsArr;
@@ -109,6 +110,7 @@ std::optional<ProjectData> ProjectFile::load(const QString& filepath) {
 
     data.stlFilePath     = root["stlFilePath"].toString();
     data.scaleFactor     = static_cast<float>(root["scaleFactor"].toDouble(1.0));
+    data.sampleRate      = root.contains("sampleRate") ? root["sampleRate"].toInt(DEFAULT_SAMPLE_RATE) : DEFAULT_SAMPLE_RATE;
     data.soundSourceFile = root["soundSourceFile"].toString();
 
     for (auto val : root["surfaceColors"].toArray())

--- a/src/core/ProjectFile.h
+++ b/src/core/ProjectFile.h
@@ -14,6 +14,7 @@ namespace prs {
 struct ProjectData {
     QString stlFilePath;
     float scaleFactor = 1.0f;
+    int sampleRate = DEFAULT_SAMPLE_RATE;
     std::vector<Color3f> surfaceColors;
     std::vector<std::optional<Material>> surfaceMaterials;
     std::vector<PlacedPoint> placedPoints;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ set(GUI_TEST_EXTRA
     ${CMAKE_SOURCE_DIR}/src/gui/widgets/ColorSwatch.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/ResourcePath.cpp
     ${CMAKE_SOURCE_DIR}/src/acoustics/SimulationWorker.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/RenderExports.cpp
     ${CMAKE_SOURCE_DIR}/src/acoustics/SimulationQueue.cpp
     ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGBasis2D.cpp
     ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGBasis3D.cpp
@@ -108,3 +109,40 @@ endif()
 target_compile_definitions(test_gui PRIVATE _USE_MATH_DEFINES)
 set_target_properties(test_gui PROPERTIES AUTOMOC ON AUTORCC ON)
 add_test(NAME test_gui COMMAND test_gui)
+
+# CLI render integration test
+set(RENDER_CLI_TEST_EXTRA
+    ${CMAKE_SOURCE_DIR}/src/acoustics/RenderExports.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/RenderPipeline.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/SimulationWorker.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/SimulationQueue.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGBasis2D.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGBasis3D.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGMesh2D.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGMesh3D.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGAcoustics2D.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGAcoustics3D.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGSolver.cpp
+    ${CMAKE_SOURCE_DIR}/src/acoustics/dg/DGGpuCompute.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/ResourcePath.cpp
+    ${CMAKE_SOURCE_DIR}/src/rendering/Viewport3D.cpp
+)
+add_executable(test_render_cli test_render_cli.cpp ${TEST_COMMON_SOURCES} ${RENDER_CLI_TEST_EXTRA})
+target_include_directories(test_render_cli PRIVATE ${TEST_INCLUDE_DIRS})
+target_link_libraries(test_render_cli PRIVATE
+    Qt6::Test Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Multimedia Qt6::Svg Eigen3::Eigen)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(test_render_cli PRIVATE OpenMP::OpenMP_CXX)
+endif()
+if(WIN32)
+    target_link_libraries(test_render_cli PRIVATE opengl32 glu32)
+elseif(APPLE)
+    find_package(OpenGL REQUIRED)
+    target_link_libraries(test_render_cli PRIVATE OpenGL::GL OpenGL::GLU)
+else()
+    find_package(OpenGL REQUIRED)
+    target_link_libraries(test_render_cli PRIVATE OpenGL::GL OpenGL::GLU)
+endif()
+target_compile_definitions(test_render_cli PRIVATE _USE_MATH_DEFINES)
+set_target_properties(test_render_cli PROPERTIES AUTOMOC ON)
+add_test(NAME test_render_cli COMMAND test_render_cli)

--- a/tests/test_render_cli.cpp
+++ b/tests/test_render_cli.cpp
@@ -1,0 +1,156 @@
+#include "audio/AudioFile.h"
+#include "core/PlacedPoint.h"
+#include "core/ProjectFile.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QProcess>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+using namespace prs;
+
+namespace {
+
+bool writeTextFile(const QString& path, const QByteArray& contents) {
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    return file.write(contents) == contents.size();
+}
+
+QString cliExecutablePath() {
+#ifdef Q_OS_WIN
+    const QString name = "SeicheRender.exe";
+#else
+    const QString name = "SeicheRender";
+#endif
+    const QDir appDir(QCoreApplication::applicationDirPath());
+    const QString local = appDir.filePath(name);
+    if (QFileInfo::exists(local))
+        return local;
+    return appDir.filePath(QStringLiteral("../%1").arg(name));
+}
+
+void writeSquarePlaneObj(const QString& path) {
+    const QByteArray obj = R"(v 0 0 0
+v 1 0 0
+v 1 1 0
+v 0 1 0
+f 1 2 3
+f 1 3 4
+)";
+    QVERIFY(writeTextFile(path, obj));
+}
+
+void writeFixtureAudio(const QString& path) {
+    AudioFile af;
+    af.samples() = {0.0f, 0.25f, 0.5f, 0.25f, 0.0f, -0.25f, -0.5f, -0.25f};
+    QVERIFY(af.save(path, 22050));
+}
+
+ProjectData makeProject() {
+    ProjectData data;
+    data.stlFilePath = "model.obj";
+    data.scaleFactor = 1.0f;
+    data.sampleRate = 22050;
+    data.soundSourceFile = "source.wav";
+    data.surfaceColors = {{0.2f, 0.4f, 0.6f}};
+    data.surfaceMaterials = {std::nullopt};
+
+    PlacedPoint source;
+    source.surfacePoint = Vec3f(0.25f, 0.25f, 0.0f);
+    source.normal = Vec3f(0.0f, 0.0f, 1.0f);
+    source.distance = 0.1f;
+    source.pointType = POINT_TYPE_SOURCE;
+    source.name = "Source";
+    source.volume = 1.0f;
+    source.audioFile.clear();
+    data.placedPoints.push_back(source);
+
+    PlacedPoint listener;
+    listener.surfacePoint = Vec3f(0.75f, 0.75f, 0.0f);
+    listener.normal = Vec3f(0.0f, 0.0f, 1.0f);
+    listener.distance = 0.1f;
+    listener.pointType = POINT_TYPE_LISTENER;
+    listener.name = "Listener";
+    listener.orientationYaw = 0.0f;
+    data.placedPoints.push_back(listener);
+
+    return data;
+}
+
+} // namespace
+
+class TestRenderCli : public QObject {
+    Q_OBJECT
+  private slots:
+    void testCliRendersFixtureProject() {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        const QString projectDir = tempDir.path();
+        writeSquarePlaneObj(QDir(projectDir).filePath("model.obj"));
+        writeFixtureAudio(QDir(projectDir).filePath("source.wav"));
+
+        ProjectData project = makeProject();
+        QVERIFY(ProjectFile::save(QDir(projectDir).filePath("fixture.room"), project));
+
+        const QString cliPath = cliExecutablePath();
+        QVERIFY2(QFileInfo::exists(cliPath), qPrintable(QString("Missing CLI executable: %1").arg(cliPath)));
+
+        const QString outputDir = QDir(projectDir).filePath("out");
+        QProcess proc;
+        proc.setProgram(cliPath);
+        proc.setArguments({"--project", QDir(projectDir).filePath("fixture.room"), "--output", outputDir, "--method",
+                           "ray", "--max-order", "1", "--n-rays", "128", "--scattering", "0.1", "--air-absorption",
+                           "off", "--sample-rate", "22050"});
+        proc.setWorkingDirectory(projectDir);
+        proc.start();
+        QVERIFY2(proc.waitForStarted(), qPrintable(proc.errorString()));
+        QVERIFY2(proc.waitForFinished(120000), "CLI render timed out");
+        QCOMPARE(proc.exitStatus(), QProcess::NormalExit);
+        QCOMPARE(proc.exitCode(), 0);
+
+        QFileInfo outInfo(outputDir);
+        QVERIFY(outInfo.exists());
+        QVERIFY(outInfo.isDir());
+
+        QDir outDir(outputDir);
+        QVERIFY(outDir.exists("scene.json"));
+        QVERIFY(outDir.exists("metrics.json"));
+        QVERIFY(outDir.exists("metrics.csv"));
+        QVERIFY(outDir.exists("summary.json"));
+
+        const QStringList wavs = outDir.entryList(QStringList() << "*.wav", QDir::Files);
+        QVERIFY2(!wavs.isEmpty(), "Expected at least one WAV output");
+
+        QFile metricsFile(outDir.filePath("metrics.json"));
+        QVERIFY(metricsFile.open(QIODevice::ReadOnly));
+        const QJsonDocument metricsDoc = QJsonDocument::fromJson(metricsFile.readAll());
+        metricsFile.close();
+        QVERIFY(metricsDoc.isObject());
+        QCOMPARE(metricsDoc.object().value("sample_rate").toInt(), 22050);
+        QVERIFY(metricsDoc.object().value("pairs").isArray());
+        QCOMPARE(metricsDoc.object().value("pairs").toArray().size(), 1);
+
+        QFile summaryFile(outDir.filePath("summary.json"));
+        QVERIFY(summaryFile.open(QIODevice::ReadOnly));
+        const QJsonDocument summaryDoc = QJsonDocument::fromJson(summaryFile.readAll());
+        summaryFile.close();
+        QVERIFY(summaryDoc.isObject());
+        QCOMPARE(summaryDoc.object().value("sample_rate").toInt(), 22050);
+
+        QFile csvFile(outDir.filePath("metrics.csv"));
+        QVERIFY(csvFile.open(QIODevice::ReadOnly | QIODevice::Text));
+        const QByteArray csvContents = csvFile.readAll();
+        csvFile.close();
+        QVERIFY(csvContents.startsWith("source,listener"));
+    }
+};
+
+QTEST_MAIN(TestRenderCli)
+#include "test_render_cli.moc"


### PR DESCRIPTION
- Add .github/workflows/ci.yml: matrix build on Linux (ubuntu-22.04), Windows, and macOS using Qt 6.7.3 and cmake --preset test
- Add CMakePresets.json with debug/release/test presets (Ninja generator, QT_QPA_PLATFORM=offscreen for headless test runs)
- Fix Eigen FetchContent to use FetchContent_Populate instead of FetchContent_MakeAvailable, avoiding spurious Fortran detection on CI
- Add SeicheRender: a headless command-line renderer that accepts a .room project file and writes WAV, JSON metrics, and CSV to an output directory
- Add RenderOptions, RenderPipeline, RenderExports to the acoustics module
- Extend SimulationWorker.Params with outputDir; use RenderExports helpers for file output instead of direct AudioFile/QFile calls
- Add sampleRate field to ProjectData with backward-compatible save/load
- Add test_render_cli integration test that exercises the CLI end-to-end